### PR TITLE
Ensure bundle is installed when `all` package is installed

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -33,6 +33,11 @@
                 <extensions>true</extensions>
                 <configuration>
                     <group>spa-project-core</group>
+                    <filters>
+                        <filter>
+                            <root>/apps/spa-project-core/install</root>
+                        </filter>
+                    </filters>
                     <embeddeds>
                         <embedded>
                             <groupId>com.adobe.aem</groupId>
@@ -47,6 +52,7 @@
                             <filter>true</filter>
                         </subPackage>
                     </subPackages>
+                    <packageType>container</packageType>
                 </configuration>
             </plugin>
             <plugin>

--- a/all/src/main/content/META-INF/vault/definition/.content.xml
+++ b/all/src/main/content/META-INF/vault/definition/.content.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright 2020 Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          jcr:primaryType="vlt:PackageDefinition"
+          providerLink="https://github.com/adobe/aem-spa-project-core/releases"
+          providerName="Adobe Systems Inc."
+          providerUrl="https://www.adobe.com"
+          testedWith="AEM 6.3, AEM 6.4">
+</jcr:root>

--- a/all/src/main/content/META-INF/vault/filter.xml
+++ b/all/src/main/content/META-INF/vault/filter.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<workspaceFilter version="1.0">
-    <filter root="/apps/spa-project-core" />
-</workspaceFilter>

--- a/pom.xml
+++ b/pom.xml
@@ -292,10 +292,62 @@
                 <plugin>
                     <groupId>org.apache.jackrabbit</groupId>
                     <artifactId>filevault-package-maven-plugin</artifactId>
-                    <version>1.0.3</version>
+                    <version>1.1.4</version>
                     <configuration>
                         <filterSource>src/main/content/META-INF/vault/filter.xml</filterSource>
+                        <failOnMissingEmbed>true</failOnMissingEmbed>
+                        <excludes>
+                            <!-- exclude .vlt control files in the package -->
+                            <exclude>**/.vlt</exclude>
+                            <exclude>**/.vltignore</exclude>
+                            <exclude>**/.gitignore</exclude>
+                            <exclude>**/*.iml</exclude>
+                            <exclude>**/.classpath</exclude>
+                            <exclude>**/.project</exclude>
+                            <exclude>**/.eslintrc</exclude>
+                            <exclude>**/.editorconfig</exclude>
+                            <exclude>**/.stylelintrc.yaml</exclude>
+                            <exclude>**/.eslintignore</exclude>
+                            <exclude>**/.settings</exclude>
+                            <exclude>**/.DS_Store</exclude>
+                            <exclude>**/target/**</exclude>
+                            <exclude>**/node/**</exclude>
+                            <exclude>**/node_modules/**</exclude>
+                            <exclude>**/pom.xml</exclude>
+                        </excludes>
+                        <validatorsSettings>
+                            <jackrabbit-filter>
+                                <options>
+                                    <validRoots>/,/apps,/apps/spa-project-core</validRoots>
+                                </options>
+                            </jackrabbit-filter>
+                            <netcentric-aem-classification>
+                                <defaultSeverity>WARN</defaultSeverity>
+                                <options>
+                                    <severitiesPerClassification>INTERNAL_DEPRECATED=WARN</severitiesPerClassification>
+                                    <maps>tccl:biz/netcentric/filevault/validator/maps/aem-classification-map-deprecations/coral2deprecations.map,tccl:biz/netcentric/filevault/validator/maps/aem-classification-map-deprecations/graniteuideprecations.map,tccl:biz/netcentric/filevault/validator/maps/aem-classification-map-repo-annotations.map</maps>
+                                </options>
+                            </netcentric-aem-classification>
+                        </validatorsSettings>
                     </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>biz.netcentric.filevault.validator</groupId>
+                            <artifactId>aem-classification-validator</artifactId>
+                            <version>1.0.0</version>
+                        </dependency>
+                        <!-- the dependency containing the actual classification map -->
+                        <dependency>
+                            <groupId>biz.netcentric.filevault.validator.maps</groupId>
+                            <artifactId>aem-classification-map-repo-annotations</artifactId>
+                            <version>6.5.3.0</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>biz.netcentric.filevault.validator.maps</groupId>
+                            <artifactId>aem-classification-map-deprecations</artifactId>
+                            <version>6.5.0.0</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <!-- Content Package Plugin -->
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -321,6 +321,11 @@
                                     <validRoots>/,/apps,/apps/spa-project-core</validRoots>
                                 </options>
                             </jackrabbit-filter>
+                            <jackrabbit-nodetypes>
+                                <options>
+                                    <cnds>tccl:aem.cnd</cnds>
+                                </options>
+                            </jackrabbit-nodetypes>
                             <netcentric-aem-classification>
                                 <defaultSeverity>WARN</defaultSeverity>
                                 <options>
@@ -346,6 +351,11 @@
                             <groupId>biz.netcentric.filevault.validator.maps</groupId>
                             <artifactId>aem-classification-map-deprecations</artifactId>
                             <version>6.5.0.0</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>biz.netcentric.aem</groupId>
+                            <artifactId>aem-nodetypes</artifactId>
+                            <version>6.5.5.0</version>
                         </dependency>
                     </dependencies>
                 </plugin>

--- a/ui.apps/pom.xml
+++ b/ui.apps/pom.xml
@@ -34,13 +34,23 @@
                 <artifactId>filevault-package-maven-plugin</artifactId>
                 <extensions>true</extensions>
                 <configuration>
-                    <group>com.adobe.aem</group>
-                    <name>spa.project.core.ui.apps</name>
+                    <filters>
+                        <filter>
+                            <root>/apps/spa-project-core/components</root>
+                        </filter>
+                    </filters>
                     <packageType>application</packageType>
                     <accessControlHandling>merge</accessControlHandling>
                     <properties>
                         <cloudManagerTarget>none</cloudManagerTarget>
                     </properties>
+                    <dependencies>
+                        <dependency>
+                            <group>day/cq60/product</group>
+                            <name>cq-platform-content</name>
+                            <version>[1.3.248,)</version>
+                        </dependency>
+                    </dependencies>
                 </configuration>
             </plugin>
             <plugin>

--- a/ui.apps/pom.xml
+++ b/ui.apps/pom.xml
@@ -34,6 +34,7 @@
                 <artifactId>filevault-package-maven-plugin</artifactId>
                 <extensions>true</extensions>
                 <configuration>
+                    <group>spa-project-core</group>
                     <filters>
                         <filter>
                             <root>/apps/spa-project-core/components</root>

--- a/ui.apps/src/main/content/META-INF/vault/definition/.content.xml
+++ b/ui.apps/src/main/content/META-INF/vault/definition/.content.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright 2020 Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          jcr:primaryType="vlt:PackageDefinition"
+          providerLink="https://github.com/adobe/aem-spa-project-core/releases"
+          providerName="Adobe Systems Inc."
+          providerUrl="https://www.adobe.com"
+          testedWith="AEM 6.3, AEM 6.4">
+</jcr:root>

--- a/ui.apps/src/main/content/META-INF/vault/filter.xml
+++ b/ui.apps/src/main/content/META-INF/vault/filter.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<workspaceFilter version="1.0">
-    <filter root="/apps/spa-project-core" />
-</workspaceFilter>

--- a/ui.apps/src/main/content/jcr_root/apps/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/.content.xml
@@ -1,2 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:rep="internal" jcr:mixinTypes="[rep:AccessControllable]" jcr:primaryType="nt:folder" />
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:rep="internal"
+      jcr:mixinTypes="[rep:AccessControllable]"
+      jcr:primaryType="sling:Folder"/>

--- a/ui.apps/src/main/content/jcr_root/apps/spa-project-core/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/spa-project-core/.content.xml
@@ -1,2 +1,3 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" jcr:primaryType="sling:Folder" />
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+      jcr:primaryType="sling:Folder"/>

--- a/ui.apps/src/main/content/jcr_root/apps/spa-project-core/components/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/spa-project-core/components/.content.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" jcr:primaryType="nt:unstructured">
-    <page />
-</jcr:root>
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+      jcr:primaryType="sling:Folder"/>


### PR DESCRIPTION
Fixes #5 

Submitting PR to master because there doesn't seem to be a development branch.

This PR:

- Updates filevault plugin
- Adds validation for the filevault plugin (largely copied from the aem-core-wcm-components project)
- Adds definition files for the filevault packages to indicate Adobe as the provider and link to this project (similar to the package metadata for aem-core-wcm-components)
- Updates the vault filters for the `ui.apps` and `all` modules so that they are mutually exclusive (thus correcting the reported bug).
- Changes the package group for the `ui.apps` module so that both the `all` and `ui.apps` are in the same package group, for easier package management.