### PR TITLE
Upgraded 'core.wcm.components' version from 2.7.0 to 2.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <sling.password>admin</sling.password>
         <vault.user>admin</vault.user>
         <vault.password>admin</vault.password>
-        <core.wcm.components.version>2.7.0</core.wcm.components.version>
+        <core.wcm.components.version>2.11.0</core.wcm.components.version>
         <bnd.version>4.2.0</bnd.version>
         <maven.release.version>2.5.3</maven.release.version>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
Updating version of [Core Components](https://docs.adobe.com/content/help/en/experience-manager-core-components/using/introduction.html) from [2.7.0](https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.7.0) to [2.11.0](https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.11.0)

Reason for the change:
1. To be in sync with the core components update
2. Based on this https://helpx.adobe.com/support/programs/eol-matrix.html , the support for AEM 6.3 ended 4/30/2020 , we can update the version of Core components from 2.7.0 (since this has support to AEM 6.5, 6.4 and 6.3)