### PR TITLE
[bug] Installing `spa.project.core.all` does not include bundle

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -37,7 +37,7 @@
                         <embedded>
                             <groupId>com.adobe.aem</groupId>
                             <artifactId>spa.project.core.core</artifactId>
-                            <target>/apps/spa-project-core/install</target>
+                            <target>/apps/spa-project-core-bundles/install</target>
                         </embedded>
                     </embeddeds>
                     <subPackages>

--- a/all/src/main/content/META-INF/vault/filter.xml
+++ b/all/src/main/content/META-INF/vault/filter.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <workspaceFilter version="1.0">
     <filter root="/apps/spa-project-core" />
+    <filter root="/apps/spa-project-core-bundles" />
 </workspaceFilter>


### PR DESCRIPTION
* fixes https://github.com/adobe/aem-spa-project-core/issues/5
* use different path for installing bundles to avoid clash