### PR TITLE
Add support for loading an experience fragment page in SPA editor mode.

### DIFF
--- a/core/src/main/java/com/adobe/aem/spa/project/core/internal/impl/ExperienceFragmentPageExporter.java
+++ b/core/src/main/java/com/adobe/aem/spa/project/core/internal/impl/ExperienceFragmentPageExporter.java
@@ -8,6 +8,6 @@ import com.adobe.cq.export.json.hierarchy.HierarchyNodeExporter;
  * Interface that allows experience fragment pages (that cannot inherit the core component page) to be exported as model JSON
  * so that the SPA editor can function properly.
  */
-public interface ExperienceFragmentPageExporter extends HierarchyNodeExporter, ContainerExporter {
+public interface ExperienceFragmentPageExporter extends ContainerExporter {
 
 }

--- a/core/src/main/java/com/adobe/aem/spa/project/core/internal/impl/ExperienceFragmentPageExporter.java
+++ b/core/src/main/java/com/adobe/aem/spa/project/core/internal/impl/ExperienceFragmentPageExporter.java
@@ -2,7 +2,6 @@ package com.adobe.aem.spa.project.core.internal.impl;
 
 
 import com.adobe.cq.export.json.ContainerExporter;
-import com.adobe.cq.export.json.hierarchy.HierarchyNodeExporter;
 
 /**
  * Interface that allows experience fragment pages (that cannot inherit the core component page) to be exported as model JSON

--- a/core/src/main/java/com/adobe/aem/spa/project/core/internal/impl/ExperienceFragmentPageExporter.java
+++ b/core/src/main/java/com/adobe/aem/spa/project/core/internal/impl/ExperienceFragmentPageExporter.java
@@ -1,0 +1,13 @@
+package com.adobe.aem.spa.project.core.internal.impl;
+
+
+import com.adobe.cq.export.json.ContainerExporter;
+import com.adobe.cq.export.json.hierarchy.HierarchyNodeExporter;
+
+/**
+ * Interface that allows experience fragment pages (that cannot inherit the core component page) to be exported as model JSON
+ * so that the SPA editor can function properly.
+ */
+public interface ExperienceFragmentPageExporter extends HierarchyNodeExporter, ContainerExporter {
+
+}

--- a/core/src/main/java/com/adobe/aem/spa/project/core/internal/impl/ExperienceFragmentPageImpl.java
+++ b/core/src/main/java/com/adobe/aem/spa/project/core/internal/impl/ExperienceFragmentPageImpl.java
@@ -1,0 +1,24 @@
+package com.adobe.aem.spa.project.core.internal.impl;
+
+import com.adobe.cq.export.json.ContainerExporter;
+import com.adobe.cq.export.json.ExporterConstants;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.models.annotations.Exporter;
+import org.apache.sling.models.annotations.Model;
+
+/**
+ * ExperienceFragmentPageImpl.
+ * @JsonSerialize is added to prevent errors being thrown in model.json export, since these don't work for this type of page.
+ */
+@Model(adaptables = SlingHttpServletRequest.class, adapters = {ExperienceFragmentPageExporter.class,
+        ContainerExporter.class}, resourceType = {
+        ExperienceFragmentPageImpl.XF_RESOURCE_TYPE
+})
+@Exporter(name = ExporterConstants.SLING_MODEL_EXPORTER_NAME, extensions = ExporterConstants.SLING_MODEL_EXTENSION)
+@JsonSerialize(as = ExperienceFragmentPageExporter.class)
+public class ExperienceFragmentPageImpl extends PageImpl implements ExperienceFragmentPageExporter {
+    
+    static final String XF_RESOURCE_TYPE = "spa-project-core/components/xf-page";
+   
+}

--- a/core/src/test/java/com/adobe/aem/spa/project/core/internal/impl/PageImplTest.java
+++ b/core/src/test/java/com/adobe/aem/spa/project/core/internal/impl/PageImplTest.java
@@ -253,4 +253,10 @@ class PageImplTest {
         verify(delegate, times(1)).getComponentsResourceTypes();
     }
 
+    @Test
+    void testGetBrandSlug() {
+        page.getBrandSlug();
+        verify(delegate, times(1)).getBrandSlug();
+    }
+
 }

--- a/core/src/test/java/com/adobe/aem/spa/project/core/internal/impl/RemotePageImplTest.java
+++ b/core/src/test/java/com/adobe/aem/spa/project/core/internal/impl/RemotePageImplTest.java
@@ -1,0 +1,49 @@
+package com.adobe.aem.spa.project.core.internal.impl;
+
+import com.adobe.aem.spa.project.core.models.RemotePage;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class RemotePageImplTest {
+
+    class NotImplementedClass implements RemotePage{}
+
+    @InjectMocks
+    private RemotePageImpl page;
+
+
+    @BeforeEach
+    void beforeEach() throws IllegalAccessException {
+        FieldUtils.writeField(page,"remoteSPAUrl",  "/dummy/url", true);
+    }
+
+
+    @Test
+    void testGetRemoteSpaUrl() {
+        // descendedPageModels is null
+        assertEquals("/dummy/url", page.getRemoteSPAUrl());
+    }
+
+    @Test
+    void testDefaultMethod(){
+        try{
+            new NotImplementedClass().getRemoteSPAUrl();
+            assertTrue(false);
+        }catch(UnsupportedOperationException ex){
+            assertTrue(true);
+        }
+
+    }
+
+}

--- a/ui.apps/src/main/content/jcr_root/apps/spa-project-core/components/xf-page/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/spa-project-core/components/xf-page/.content.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0"
+          xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          jcr:primaryType="cq:Component"
+          componentGroup=".core-wcm"
+          cq:icon="page"
+          jcr:title="Experience Fragment Page"
+          sling:resourceSuperType="cq/experience-fragments/components/xfpage"/>


### PR DESCRIPTION
## Description

This is done by adding a resource type that extends cq/experience-fragments/components/xf-page.
Since this type does not support core components (it doesn't inherit the core component page), the model's core components functions don't work.

Therefore a JsonSerialze(as=...) is used to prevent errors being thrown in the model.json.


## Related Issue

https://github.com/adobe/aem-spa-project-core/issues/25
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

I tested this in my implementation project with an experience fragment.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
