### PR TITLE
Set File encoding to utf-8 to stop warnings in build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
         <core.wcm.components.version>2.11.1</core.wcm.components.version>
         <bnd.version>4.2.0</bnd.version>
         <maven.release.version>2.5.3</maven.release.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <sonar.organization>adobeinc</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Set File encoding to utf-8 

<!--- Describe your changes in detail -->
Set `project.build.sourceEncoding` properties in the pom file to `UTF-8` to avoid warnings in the build.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/adobe/aem-spa-project-core/issues/29

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Exact warnings reported in the build were -
`[WARNING] File encoding has not been set, using platform encoding UTF-8, i.e. build is platform dependent!`
and
`[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!`

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
By building the project and verifying that there are no longer such warnings

## Screenshots (if appropriate):
NA

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
