### PR TITLE
Adding HierarchyNodeExporter to fix XF's not being editable

### DIFF
--- a/core/src/main/java/com/adobe/aem/spa/project/core/internal/impl/ExperienceFragmentPageExporter.java
+++ b/core/src/main/java/com/adobe/aem/spa/project/core/internal/impl/ExperienceFragmentPageExporter.java
@@ -2,11 +2,12 @@ package com.adobe.aem.spa.project.core.internal.impl;
 
 
 import com.adobe.cq.export.json.ContainerExporter;
+import com.adobe.cq.export.json.hierarchy.HierarchyNodeExporter;
 
 /**
  * Interface that allows experience fragment pages (that cannot inherit the core component page) to be exported as model JSON
  * so that the SPA editor can function properly.
  */
-public interface ExperienceFragmentPageExporter extends ContainerExporter {
+public interface ExperienceFragmentPageExporter extends ContainerExporter, HierarchyNodeExporter {
 
 }


### PR DESCRIPTION
This fixes the XF page not being editable in the site admin for SPA pages.