### PR TITLE
Split off the pageurl exporter to a separate interface

### DIFF
--- a/core/src/main/java/com/adobe/aem/spa/project/core/internal/impl/PageHierarchyRootExporterImpl.java
+++ b/core/src/main/java/com/adobe/aem/spa/project/core/internal/impl/PageHierarchyRootExporterImpl.java
@@ -1,0 +1,77 @@
+package com.adobe.aem.spa.project.core.internal.impl;
+
+import com.adobe.aem.spa.project.core.internal.impl.utils.HierarchyUtils;
+import com.adobe.aem.spa.project.core.internal.impl.utils.RequestUtils;
+import com.adobe.aem.spa.project.core.internal.impl.utils.StyleUtils;
+import com.adobe.aem.spa.project.core.models.PageHierarchyRootExporter;
+import com.day.cq.wcm.api.Page;
+import com.day.cq.wcm.api.designer.Style;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
+import org.apache.sling.models.annotations.injectorspecific.ScriptVariable;
+import org.apache.sling.models.annotations.injectorspecific.Self;
+import org.jetbrains.annotations.Nullable;
+
+@Model(adaptables = SlingHttpServletRequest.class, adapters = {PageHierarchyRootExporter.class})
+public class PageHierarchyRootExporterImpl implements PageHierarchyRootExporter {
+
+    // Delegated to Page v1
+    @ScriptVariable
+    private com.day.cq.wcm.api.Page currentPage;
+
+    @ScriptVariable(injectionStrategy = InjectionStrategy.OPTIONAL)
+    @JsonIgnore
+    private Style currentStyle;
+
+    // Delegated to Page v2
+    @Self
+    private SlingHttpServletRequest request;
+
+    @ScriptVariable
+    private Resource resource;
+
+    private com.day.cq.wcm.api.Page rootPage;
+
+
+    @Nullable
+    @Override
+    public String getHierarchyRootJsonExportUrl() {
+        if (isRootPage()) {
+            return RequestUtils.getPageJsonExportUrl(request, currentPage);
+        }
+
+        if (rootPage == null) {
+            setRootPage(HierarchyUtils.getRootPage(resource, currentPage));
+        }
+
+        if (rootPage != null) {
+            return RequestUtils.getPageJsonExportUrl(request, rootPage);
+        }
+        return null;
+    }
+
+    @Override
+    public Page getRootPage() {
+
+        if (rootPage == null) {
+            setRootPage(HierarchyUtils.getRootPage(resource, currentPage));
+        }
+
+        return rootPage;
+    }
+
+    private boolean isRootPage() {
+        return currentStyle != null && StyleUtils.isRootPage(currentStyle);
+    }
+
+    /**
+     * Package-private setter for rootPage (required for tests)
+     */
+    void setRootPage(com.day.cq.wcm.api.Page rootPage) {
+        this.rootPage = rootPage;
+    }
+
+}

--- a/core/src/main/java/com/adobe/aem/spa/project/core/models/Page.java
+++ b/core/src/main/java/com/adobe/aem/spa/project/core/models/Page.java
@@ -27,22 +27,12 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
  * Defines the {@code Page} Sling Model used for the {@code /apps/spa/project/core/models/page} component
  */
 @ConsumerType
-public interface Page extends com.adobe.cq.wcm.core.components.models.Page, HierarchyNodeExporter {
+public interface Page extends com.adobe.cq.wcm.core.components.models.Page, HierarchyNodeExporter, PageHierarchyRootExporter {
     /**
      * Key for the depth of the tree of pages that is to be exported
      */
     String PN_STRUCTURE_DEPTH = "structureDepth";
 
-    /**
-     * URL to the root model of the App
-     *
-     * @return {@link String}
-     */
-    @Nullable
-    @JsonIgnore
-    default String getHierarchyRootJsonExportUrl() {
-        throw new UnsupportedOperationException();
-    }
 
     /**
      * Root page model of the current hierarchy of pages

--- a/core/src/main/java/com/adobe/aem/spa/project/core/models/PageHierarchyRootExporter.java
+++ b/core/src/main/java/com/adobe/aem/spa/project/core/models/PageHierarchyRootExporter.java
@@ -1,0 +1,32 @@
+package com.adobe.aem.spa.project.core.models;
+
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Exports the HierarchyRootUrl for the SPA application to fetch
+ */
+public interface PageHierarchyRootExporter {
+
+    /**
+     * URL to the root model of the App
+     *
+     * @return {@link String}
+     */
+    @Nullable
+    @JsonIgnore
+    default String getHierarchyRootJsonExportUrl() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Get the root page of the SPA application
+     * @return
+     */
+    @JsonIgnore
+    default com.day.cq.wcm.api.Page getRootPage(){
+        throw new UnsupportedOperationException();
+    }
+
+}

--- a/core/src/main/java/com/adobe/aem/spa/project/core/models/package-info.java
+++ b/core/src/main/java/com/adobe/aem/spa/project/core/models/package-info.java
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-@Version("1.1.0")
+@Version("1.2.0")
 package com.adobe.aem.spa.project.core.models;
 
 import org.osgi.annotation.versioning.Version;


### PR DESCRIPTION
Final change needed for the experience fragments to work.

The experience fragment template needs the model JSON root URL, but does not inherit the core components page.

Splitting this will allow the adaption and thus retrieval of the model json root URL, and therefore the rendering.
Delegate pattern applied to reuse code, tested extensively against instances.