### PR TITLE
fix: default relative remote path to origin

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/spa-project-core/components/remotepage/clientlibs/js/remotepage.js
+++ b/ui.apps/src/main/content/jcr_root/apps/spa-project-core/components/remotepage/clientlibs/js/remotepage.js
@@ -34,12 +34,13 @@
     };
 
     const sanitizeUrl = (url) => {
-        let { pathname, origin } = new URL(url);
+        let { pathname, origin } = new URL(url, location.origin); // defaults to own origin
         pathname = pathname.replace(/\/\//, '/');
         return `${origin}${pathname}`;
     };
 
      const domain = document.body.dataset.remoteUrl;
+
      if(domain) {
          const manifestUrl = sanitizeUrl(`${domain}/asset-manifest.json`);
          fetch(manifestUrl)


### PR DESCRIPTION
Defaulting remote url to own domain

## Description

Use cases for this are:

- Putting remote page into aem
- Having remote page under same origin

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
