### PR TITLE
fix: inherit remote spa url

### DIFF
--- a/core/src/main/java/com/adobe/aem/spa/project/core/internal/impl/RemotePageImpl.java
+++ b/core/src/main/java/com/adobe/aem/spa/project/core/internal/impl/RemotePageImpl.java
@@ -14,10 +14,15 @@ package com.adobe.aem.spa.project.core.internal.impl;
 import com.adobe.aem.spa.project.core.models.RemotePage;
 import com.adobe.cq.export.json.ContainerExporter;
 import com.adobe.cq.export.json.ExporterConstants;
+import com.day.cq.commons.inherit.InheritanceValueMap;
+import com.day.cq.wcm.api.Page;
+import com.day.cq.commons.inherit.HierarchyNodeInheritanceValueMap;
+import com.day.cq.wcm.api.PageManager;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.models.annotations.DefaultInjectionStrategy;
 import org.apache.sling.models.annotations.Exporter;
 import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.injectorspecific.Self;
 import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
 
 /**
@@ -36,11 +41,26 @@ public class RemotePageImpl extends PageImpl implements RemotePage {
     static final String RESOURCE_TYPE_SPA = "spa-project-core/components/remotepage";
     static final String RESOURCE_TYPE_NEXT = "spa-project-core/components/remotepagenext";
 
+    @Self
+    private SlingHttpServletRequest request;
+
      @ValueMapValue
      private String remoteSPAUrl;
 
      @Override
      public String getRemoteSPAUrl() {
-         return remoteSPAUrl;
-     }
+        String spaUrl = "";
+
+        if(remoteSPAUrl != null) {
+            spaUrl = remoteSPAUrl;
+        } else {
+            PageManager pageManager = request.getResourceResolver().adaptTo(PageManager.class);
+            Page page = pageManager.getContainingPage(request.getResource());
+            if(page != null) {
+                InheritanceValueMap pageProperties = new HierarchyNodeInheritanceValueMap(page.getContentResource());
+                spaUrl = pageProperties.getInherited("remoteSPAUrl", "");
+            }
+        }
+        return spaUrl;
+    }
 }

--- a/core/src/test/java/com/adobe/aem/spa/project/core/internal/impl/RemotePageImplTest.java
+++ b/core/src/test/java/com/adobe/aem/spa/project/core/internal/impl/RemotePageImplTest.java
@@ -1,17 +1,22 @@
 package com.adobe.aem.spa.project.core.internal.impl;
 
 import com.adobe.aem.spa.project.core.models.RemotePage;
+import com.day.cq.wcm.api.PageManager;
 import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.ResourceResolver;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -22,15 +27,29 @@ public class RemotePageImplTest {
     @InjectMocks
     private RemotePageImpl page;
 
+    @Mock
+    SlingHttpServletRequest request;
 
-    @BeforeEach
-    void beforeEach() throws IllegalAccessException {
-        FieldUtils.writeField(page,"remoteSPAUrl",  "/dummy/url", true);
+    @Mock
+    ResourceResolver resourceResolver;
+
+    @Mock
+    PageManager pageManager;
+
+     @BeforeEach
+     void beforeEach() {
+         when(request.getResourceResolver()).thenReturn(resourceResolver);
+         when(resourceResolver.adaptTo(PageManager.class)).thenReturn(pageManager);
     }
 
+    @Test
+    void testDefaultRemoteSpaUrl() {
+        assertEquals("", page.getRemoteSPAUrl());
+    }
 
     @Test
-    void testGetRemoteSpaUrl() {
+    void testGetRemoteSpaUrl() throws IllegalAccessException {
+        FieldUtils.writeField(page,"remoteSPAUrl",  "/dummy/url", true);
         // descendedPageModels is null
         assertEquals("/dummy/url", page.getRemoteSPAUrl());
     }


### PR DESCRIPTION
## Description

Inherit SPA URL for remote page components if none are provided for a page

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
