### PR TITLE
Add next head count meta tag

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/spa-project-core/components/remotepagenext/remotepagenext.html
+++ b/ui.apps/src/main/content/jcr_root/apps/spa-project-core/components/remotepagenext/remotepagenext.html
@@ -21,6 +21,7 @@
     <meta property="cq:datatype" data-sly-test="${wcmmode.edit || wcmmode.preview}" content="JSON" />
     <meta property="cq:wcmmode" data-sly-test="${wcmmode.edit}" content="edit" />
     <meta property="cq:wcmmode" data-sly-test="${wcmmode.preview}" content="preview" />
+    <meta name="next-head-count" />
 	<sly data-sly-call="${head.head @ page = page}"></sly>
   </head>
 


### PR DESCRIPTION
Since next v.12.2, the `next-head-count` meta tag is required in document head so that Next.js does not give error.