### PR TITLE
SITES-7941: delegate PageImpl#getHtmlPageItems()

### DIFF
--- a/core/src/main/java/com/adobe/aem/spa/project/core/internal/impl/PageImpl.java
+++ b/core/src/main/java/com/adobe/aem/spa/project/core/internal/impl/PageImpl.java
@@ -13,6 +13,7 @@
 package com.adobe.aem.spa.project.core.internal.impl;
 
 import java.util.Calendar;
+import java.util.List;
 import java.util.Map;
 
 import java.util.Set;
@@ -39,6 +40,7 @@ import com.adobe.cq.export.json.ComponentExporter;
 import com.adobe.cq.export.json.ContainerExporter;
 import com.adobe.cq.export.json.ExporterConstants;
 import com.adobe.cq.export.json.hierarchy.type.HierarchyTypes;
+import com.adobe.cq.wcm.core.components.models.HtmlPageItem;
 import com.adobe.cq.wcm.core.components.models.NavigationItem;
 import com.day.cq.wcm.api.designer.Style;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -318,4 +320,9 @@ public class PageImpl implements Page {
 		return delegate.getBrandSlug();
 	}
 
+    @Nullable
+    @Override
+    public  List<HtmlPageItem> getHtmlPageItems() {
+        return delegate.getHtmlPageItems();
+    }
 }

--- a/core/src/test/java/com/adobe/aem/spa/project/core/internal/impl/PageImplTest.java
+++ b/core/src/test/java/com/adobe/aem/spa/project/core/internal/impl/PageImplTest.java
@@ -259,4 +259,10 @@ class PageImplTest {
         verify(delegate, times(1)).getBrandSlug();
     }
 
+    @Test
+    void testHtmlPageItems() {
+        page.getHtmlPageItems();
+        verify(delegate, times(1)).getHtmlPageItems();
+    }
+
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In order to support the frontend pipeline we have to render the html page items configured in a context aware configuration to the page head/footer. This is done already in inherited head and footer htl templates. However the Page model needs to expose those configurations to the template which is not the case yet.

## Related Issue

SITES-7941

## Motivation and Context

Add an example of a decoupled frontend build SPA project to the aem-project-archetype.

## How Has This Been Tested?

Locally and with unit tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
