### PR TITLE
Change sling:resourceSuperType of the spa page to the V3 core compone…nt page

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <sling.password>admin</sling.password>
         <vault.user>admin</vault.user>
         <vault.password>admin</vault.password>
-        <core.wcm.components.version>2.15.0</core.wcm.components.version>
+        <core.wcm.components.version>2.26.0</core.wcm.components.version>
         <bnd.version>4.2.0</bnd.version>
         <maven.release.version>2.5.3</maven.release.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/ui.apps/src/main/content/jcr_root/apps/spa-project-core/components/page/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/spa-project-core/components/page/.content.xml
@@ -1,2 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" cq:icon="page" jcr:primaryType="cq:Component" jcr:title="Page (v3)" sling:resourceSuperType="core/wcm/components/page/v2/page" componentGroup=".core-wcm" designDialogPath="spa-project-core/components/page/cq:design_dialog" />
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0"
+          xmlns:jcr="http://www.jcp.org/jcr/1.0" cq:icon="page" jcr:primaryType="cq:Component" jcr:title="Page (v3)"
+          sling:resourceSuperType="core/wcm/components/page/v3/page" componentGroup=".core-wcm"
+          designDialogPath="spa-project-core/components/page/cq:design_dialog"/>


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

The SPA Project Core in AEM is referencing an outdated WCM CORE Page version (v2), which is causing issues with SPA pages. The component should reference the latest version (v3).
Issue example from log file

27.09.2024 17:10:21.522 *ERROR* [[0:0:0:0:0:0:0:1] [1727449821507] GET /content/wknd-spa-react/us/en/home.html HTTP/1.1] com.day.cq.wcm.core.impl.WCMDeveloperModeFilter Error during include of SlingRequestPathInfo: path='/content/wknd-spa-react/us/en/home/jcr:content', selectorString='null', extension='html', suffix='null'
org.apache.sling.scripting.sightly.SightlyException: Identifier com.adobe.aem.spa.project.core.models.Page cannot be correctly instantiated by the Use API

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Its fixing blank page for [aem-spa-project-core](https://github.com/adobe/aem-spa-project-core)

## How Has This Been Tested?
AEM SDK

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
